### PR TITLE
Add options.configFile to use external RequireJS configurations

### DIFF
--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -13,6 +13,9 @@
   <% if (options.configFile) { %>
     <script src="<%= options.configFile %>"></script>
   <% } %>
+  
+    <script src="<%= temp %>/require.js"></script>
+  
   <% if (options.requireConfig) { %>
     <script>
       var require = (function(){
@@ -30,7 +33,6 @@
       })();    
     </script>
   <% } %>
-  <script src="<%= temp %>/require.js"></script>
   <% css.forEach(function(style){ %>
   <link rel="stylesheet" type="text/css" href="<%= style %>">
   <% }) %>


### PR DESCRIPTION
Added options.configFile to the template in order to pull in an external RequireJS config. This promotes reuse of the application config, keeps from having to copy an entire config into the Gruntfile, and still allows override of application config options. This is based on the example given in http://requirejs.org/docs/api.html#config.
