### PR TITLE
Fixed the requirejs version map pointing '2.1.2' to 'requirejs-2.1.1'

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -4,7 +4,7 @@
 var template = __dirname + '/templates/jasmine-requirejs.html',
     requirejs  = {
       '2.1.1' : __dirname + '/../vendor/require-2.1.1.js',
-      '2.1.2' : __dirname + '/../vendor/require-2.1.1.js'
+      '2.1.2' : __dirname + '/../vendor/require-2.1.2.js'
     };
 
 exports.process = function(grunt, task, context) {


### PR DESCRIPTION
A typo in requirejs version map was making the script use requirejs
2.1.1 regardless of the version parameter.
