### PR TITLE
Throw explicit error when undefined requirejs version is specified

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -41,7 +41,11 @@ exports.process = function(grunt, task, context) {
     });
   }
 
-  task.copyTempFile(requirejs[version],'require.js');
+  if (!(version in requirejs)) {
+      throw new Error('specified requirejs version [' + version + '] is not defined');
+  } else {
+      task.copyTempFile(requirejs[version],'require.js');
+  }
 
   var source = grunt.file.read(template);
   return grunt.util._.template(source, context);


### PR DESCRIPTION
If you specify an old version of requirejs, the error msg from grunt is unfriendly.
