### PR TITLE
Move require up above helper and vendor script references.  

### DIFF
--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <title>Jasmine Spec Runner</title>
 
+  <script src="<%= temp %>/require.js"></script>
   <% with (scripts) { %>
   <% [].concat(jasmine, vendor, helpers).forEach(function(script){ %>
   <script src="<%= script %>"></script>
   <% }) %>
   <% }; %>
 
-  <script src="<%= temp %>/require.js"></script>
   <script>
     <% if (options.requireConfig) { %>
       require.config(<%= JSON.stringify(options.requireConfig) %>);


### PR DESCRIPTION
Allows for specifying require config files in the helpers. 

```
jasmine: {
  src: 'app',
  options: {
    helpers: [
      'app/config.js'
    ],
    specs: ['spec/out/*_spec.js'],
    template: require('grunt-template-jasmine-requirejs')
  }
}
```
