### PR TITLE
Filter the *Spec.js to run the tests against

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
       requirejs: {
         src: 'test/fixtures/requirejs/src/**/*.js',
         options: {
-          specs: 'test/fixtures/requirejs/spec/*Spec.js',
+          specs: 'test/fixtures/requirejs/spec/**/*Spec.js',
           helpers: 'test/fixtures/requirejs/spec/*Helper.js',
           host: 'http://127.0.0.1:<%= connect.test.port %>/',
           template: require('./'),


### PR DESCRIPTION
These changes allow for a more granular control over which `*Spec.js` file to run via the command line, without having to go into `Gruntfile.js`.

**filename**
`grunt test --spec foo` will run spec files that have `foo` in their file name.
`grunt test --spec foo,bar` will run spec files that have `foo` or `bar` in their file name.

**folder**
`grunt test --spec /foo` will run anything that is located within a folder `/foo*`
`grunt test --spec /*-bar` will run anything that is located in a folder `/*-bar`

Given the following `/test` folder hierarchy:

```
test
  |_ spec
     |_ sumSpec.js
     |_ mathSpec.js
     |_ testSpec.js
     |_ math-folder
        |_ sinSpec.js
        |_ cosSpec.js
        |_ tanSpec.js
```

`grunt test --spec math` will run `MathSpec.js` only.
`grunt test --spec /math` will run the spec files located in the `math-folder`.
`grunt test --spec math,test` will run `MathSpec.js` and `testSpec.js`.
