### PR TITLE
Add option to allow use of custom require.js from local file system

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,31 @@
 module.exports = function(grunt) {
   "use strict";
 
+  var defaultTemplateOptions = {
+    requireConfigFile: 'test/fixtures/requirejs/src/main.js',
+    requireConfig : {
+      baseUrl: './test/fixtures/requirejs/src/',
+      config: {
+        sum: {
+          description: "Sum module (overridden)"
+        }
+      },
+      "shim": {
+        "fakeShim": {
+          "exports": 'fakeShim',
+          "init": function () {
+            return "this is fake shim";
+          }
+        }
+      },
+      "callback": function() {
+        define('inlineModule', function() {
+          return 'this is inline module';
+        });
+      }
+    }
+  };
+  
   // Project configuration.
   grunt.initConfig({
     // Task configuration.
@@ -52,30 +77,18 @@ module.exports = function(grunt) {
           helpers: 'test/fixtures/requirejs/spec/*Helper.js',
           host: 'http://127.0.0.1:<%= connect.test.port %>/',
           template: require('./'),
-          templateOptions: {
-            requireConfigFile: 'test/fixtures/requirejs/src/main.js',
-            requireConfig : {
-              baseUrl: './test/fixtures/requirejs/src/',
-              config: {
-                sum: {
-                  description: "Sum module (overridden)"
-                }
-              },
-              "shim": {
-                "fakeShim": {
-                  "exports": 'fakeShim',
-                  "init": function () {
-                    return "this is fake shim";
-                  }
-                }
-              },
-              "callback": function() {
-                define('inlineModule', function() {
-                  return 'this is inline module';
-                });
-              }
-            }
-          }
+          templateOptions: defaultTemplateOptions
+        }
+      },
+
+      version_path_test: {
+        src: 'test/fixtures/requirejs/src/**/*.js',
+        options: {
+          specs: 'test/fixtures/requirejs/spec/*Spec.js',
+          helpers: 'test/fixtures/requirejs/spec/*Helper.js',
+          host: 'http://127.0.0.1:<%= connect.test.port %>/',
+          template: require('./'),
+          templateOptions: grunt.util._.extend({version: "vendor/require-2.1.8.js"}, defaultTemplateOptions)
         }
       },
       parse_test: {
@@ -119,7 +132,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-contrib-connect');
 
-  grunt.registerTask('test', ['connect', 'jasmine:requirejs']);
+  grunt.registerTask('test', ['connect', 'jasmine:requirejs', 'jasmine:version_path_test']);
   grunt.registerTask('parse_test', ['connect', 'jasmine:parse_test']);
 
   // Default task.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ npm install grunt-template-jasmine-requirejs --save-dev
 
 ### templateOptions.version
 Type: `String`
-Options: `2.0.0` to `2.1.8`
-Default: latest requirejs version included
+Options: `2.0.0` to `2.1.8` or path to a local file system version. Default: latest requirejs version included
 
 The version of requirejs to use.
 

--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -39,7 +39,7 @@ function moveRequireJs(grunt, task, version) {
   if (version in requirejs) {
     pathToRequireJS = requirejs[version];
   } else if (grunt.file.exists(version)) {
-    pathToRequireJS = version; 
+    pathToRequireJS = version;
   } else {
     throw new Error('specified requirejs version [' + version + '] is not defined');
   }


### PR DESCRIPTION
Change to allow grunt-template-jasmine-requirejs to support using a custom version of require.js.  The scenario is when there is a need for either a bleeding edge version of requirejs that is not in the vendor folder yet or a custom fork of requirejs.  In either of these cases, this pull request would allow users to enter a local file path to their custom require.js in the version option instead of a version number. 
