### PR TITLE
new option for require.js (addresses Issue #36)

### DIFF
--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -8,7 +8,12 @@
   <link rel="stylesheet" type="text/css" href="<%= style %>">
   <% }) %>
 
-  <script src="<%= temp %>/require.js"></script>
+  <% if (options.requireFile) { %>
+    <script src="<%= options.requireFile %>"></script>
+  <% } else { %>
+    <script src="<%= temp %>/require.js"></script>
+  <% } %>
+  
   <script>
     require.onError = function(error) {
       var message = error.requireType + ': ';


### PR DESCRIPTION
new option for specifying custom path to  (relative to _SpecRunner.html)

example:

```
options: {
    outfile: "custom/path/to/_SpecRunner.html",
    specs: "path/to/spec/*Spec.js",
    template: require('grunt-template-jasmine-requirejs'),
    templateOptions: {
        requireFile: "../js/libs/require.min.js", //relative to outfile
        requireConfigFile: ['path/to/src/config.js' ],
        requireConfig: {
            baseUrl: '../src/'
        }
    },
}
```
