### PR TITLE
Adding ignoreFiles option.

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -34,6 +34,20 @@ function filterGlobPatterns(scripts) {
   });
 }
 
+function filterFiles(scripts, ignore) {
+  ignore = Array.isArray(ignore) ? ignore : [];
+  Object.keys(scripts).forEach(function (group) {
+    if (Array.isArray(scripts[group])) {
+      scripts[group] = scripts[group].filter(function(script) {
+        if (ignore.indexOf(script) === 0) {
+          return false;
+        }
+        return true;
+      });
+    }
+  });
+}
+
 function resolvePath(filepath) {
   filepath = filepath.trim();
   if (filepath.substr(0,1) === '~') {
@@ -72,6 +86,9 @@ exports.process = function(grunt, task, context) {
 
   // Remove glob patterns from scripts (see https://github.com/gruntjs/grunt-contrib-jasmine/issues/42)
   filterGlobPatterns(context.scripts);
+
+  // Filter out files that user has defined.
+  filterFiles(context.scripts, context.options.ignoreFiles);
 
   // Extract config from main require config file
   if (context.options.requireConfigFile) {


### PR DESCRIPTION
Some files that were loaded through async caused some issues in the dependency tree where it would periodically timeout. A good example of this would be Google Maps through the "async!" parameter. However, because this isn't needed for testing and the timeout would make the tests fail unpredictably. Therefore there should be an ability to ignore files from the template during testing time as it should not be included in the dependency tree.

Usage:

```
templateOptions: {
  ignoreFiles: ["exact/file/path.js", ...]
}
```
