### PR TITLE
Fix for #52 - Change contexts temp value according jasmine script sources

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -113,6 +113,13 @@ exports.process = function(grunt, task, context) {
   // Remove baseUrl and .js from src files
   context.scripts.src = grunt.util._.map(context.scripts.src, getRelativeModuleUrl);
 
+  // Reset temp value depending on jasmine sources:
+  if (context.scripts.jasmine.length > 0) {
+    var tempPrefix = context.scripts.jasmine[0].match(/^(.*)\.grunt/);
+    if (tempPrefix && tempPrefix.length === 2) {
+      context.temp = context.temp.replace(/\.grunt/, tempPrefix[1] + '.grunt');
+    }
+  }
 
   // Prepend loaderPlugins to the appropriate files
   if (context.options.loaderPlugin) {


### PR DESCRIPTION
This should fix the issue when a wrong path to require.js lib is used
when jasmines outfile option is specified.
