### PR TITLE
Fix loaderPlugin

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -117,9 +117,9 @@ exports.process = function(grunt, task, context) {
   // Prepend loaderPlugins to the appropriate files
   if (context.options.loaderPlugin) {
     Object.keys(context.options.loaderPlugin).forEach(function(type){
-      if (context[type]) {
-        context[type].forEach(function(file,i){
-          context[type][i] = context.options.loaderPlugin[type] + '!' + file;
+      if (context.scripts[type]) {
+        context.scripts[type].forEach(function(file,i){
+          context.scripts[type][i] = context.options.loaderPlugin[type] + '!' + file;
         });
       }
     });


### PR DESCRIPTION
It looks like at some point the module names were moved from `context` out to `context.scripts`.

It's not clear to me how to write a test for this. I tried copying `require-baseurl` into `require-loader`, but I can't get the new test to run with no modifications.

```
Running "jasmine:require-loader" (jasmine) task
Testing jasmine specs via phantom
>> Error: scripterror: Illegal path or script error: ['app'] at
>> _SpecRunner.html:21 
>> .grunt/grunt-contrib-jasmine/require.js:12 v
>> .grunt/grunt-contrib-jasmine/require.js:29 
```

output from: https://github.com/AsaAyers/grunt-template-jasmine-requirejs/commit/af02ba802f72cf995e29c82597fb79ca01b000e9
