### PR TITLE
Changed grunt-contrib-jasmine filename to 'boot'.

### DIFF
--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -73,7 +73,7 @@
     ],
     function(){
       require(['<%= [].concat(scripts.specs,scripts.reporters).join("','") %>'], function(){
-        require(['<%= scripts.start.join("','") %>'], function(){
+        require(['<%= scripts.boot.join("','") %>'], function(){
           // good to go! Our tests should already be running.
         })
       })


### PR DESCRIPTION
Seems to be the grunt-contrib-jasmine start filename was changed to 'boot'.

Reference:
https://github.com/gruntjs/grunt-contrib-jasmine/commit/a78d1cd558fd72a8deffb8f9e4224cfa40f97cc9#diff-89bb54896c62883d09e7a2f3882fa57dL92
