### PR TITLE
Adding an option to override the default SpecRunner template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ This object is `JSON.stringify()`-ed ( **support serialize Function object** ) i
 
 If `requireConfigFile` is specified then it will be loaded first and the settings specified by this directive will be deep-merged onto those.
 
+### templateOptions.specRunnerTemplate
+Type: `String`
+
+If you wish to override the template version of the SpecRunner.html that is built out (for customizing), then you can provide the path for this. If you wish to alter the template, you can create a copy from [here](https://github.com/cloudchen/grunt-template-jasmine-requirejs/blob/master/src/templates/jasmine-requirejs.html). If `specRunnerTemplate` is provided and the file exists, it uses this file, otherwise it falls back to the default built in template.
 
 ## Sample usage
 

--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -168,7 +168,9 @@ exports.process = function(grunt, task, context) {
   // update relative path of .grunt folder to the location of spec runner
   context.temp = path.relative(path.dirname(context.outfile),
                                context.temp);
-
+  if (context.options.specRunnerTemplate && grunt.file.exists(context.options.specRunnerTemplate)) {
+      template = context.options.specRunnerTemplate;
+  }
   var source = grunt.file.read(template);
   return grunt.util._.template(source, context);
 };


### PR DESCRIPTION
We had an issue whereby the requirejs code at the bottom of the outputted _SpecRunner.html file was including all of the jasmine.src files, that we actually didn't need to be included in the SpecRunner file, but we needed to specify them because https://github.com/maenu/grunt-template-jasmine-istanbul#templateoptionsfiles doesn't appear to instrument any of these files, only the ones in jasmine.src.

One bug aside, I can see use cases where users may want to customize their SpecRunner.html file
