### PR TITLE
Include polyfills in jasmine-requirejs.html; include original (full) stack trace in onError output

### DIFF
--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -83,7 +83,7 @@
       <% }) %>
     ],
     function(){
-      require(['<%= [].concat(scripts.specs,scripts.reporters).join("','") %>'], function(){
+      require(['<%= [].concat(scripts.polyfills,scripts.specs,scripts.reporters).join("','") %>'], function(){
         startTests();
       });
     }

--- a/src/templates/jasmine-requirejs.html
+++ b/src/templates/jasmine-requirejs.html
@@ -30,6 +30,7 @@
       } else {
         message += error.message;
       }
+      message += '\nOriginal stack trace:\n' + error.stack;
 
       throw Error(message);
     };


### PR DESCRIPTION
This PR is for two minor issues I had using this template with grunt-contrib-jasmine. Some simple one line changes:
- The template now loads polyfills as part of its require (e.g. es5-shim)
- The error output did not include the full stack trace

Thanks!
