### PR TITLE
Support grunt-contrib-jasmine 1.2.0 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-jshint": "~2.0.0",
     "grunt-contrib-watch": "~1.1.0",
     "grunt": "~1.0.3",
-    "grunt-contrib-jasmine": "1.0.3",
+    "grunt-contrib-jasmine": "~2.0.2",
     "grunt-contrib-connect": "~2.0.0",
     "grunt-bump": "0.8.0",
     "grunt-npm": "0.0.2"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-jshint": "~2.0.0",
     "grunt-contrib-watch": "~1.1.0",
     "grunt": "~1.0.3",
-    "grunt-contrib-jasmine": "~2.0.2",
+    "grunt-contrib-jasmine": "1.0.3",
     "grunt-contrib-connect": "~2.0.0",
     "grunt-bump": "0.8.0",
     "grunt-npm": "0.0.2"

--- a/package.json
+++ b/package.json
@@ -41,12 +41,15 @@
   ],
   "license": "BSD",
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.4",
-    "grunt-contrib-watch": "~0.1.4",
-    "grunt": "~0.4.1",
-    "grunt-contrib-jasmine": "~0.6",
-    "grunt-contrib-connect": "~0.2.0",
-    "grunt-bump": "0.0.13",
+    "grunt-contrib-jshint": "~2.0.0",
+    "grunt-contrib-watch": "~1.1.0",
+    "grunt": "~1.0.3",
+    "grunt-contrib-jasmine": "~2.0.2",
+    "grunt-contrib-connect": "~2.0.0",
+    "grunt-bump": "0.8.0",
     "grunt-npm": "0.0.2"
+  },
+  "dependencies": {
+    "lodash": "~4.17.11"
   }
 }

--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -45,7 +45,7 @@ function resolvePath(filepath) {
   return path.resolve(filepath);
 }
 
-function moveRequireJs(grunt, task, versionOrPath) {
+function moveRequireJs(grunt, tempDir, versionOrPath) {
   var pathToRequireJS,
       versionReg = /^(\d\.?)*$/;
 
@@ -61,7 +61,7 @@ function moveRequireJs(grunt, task, versionOrPath) {
         throw new Error('local file path of requirejs [' + versionOrPath + '] was not found');
       }
   }
-  task.copyTempFile(pathToRequireJS,'require.js');
+  grunt.file.copy(pathToRequireJS, path.join(tempDir, 'require.js'));
 }
 
 exports.process = function(grunt, task, context) {
@@ -134,7 +134,7 @@ exports.process = function(grunt, task, context) {
     });
   }
 
-  moveRequireJs(grunt, task, version);
+  moveRequireJs(grunt, context.temp, version);
 
   context.serializeRequireConfig = function(requireConfig) {
     var funcCounter = 0;

--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var _ = require('lodash');
 var template = __dirname + '/templates/jasmine-requirejs.html',
     requirejs  = {
       '2.0.0' : __dirname + '/../vendor/require-2.0.0.js',
@@ -78,21 +79,21 @@ exports.process = function(grunt, task, context) {
   // Extract config from main require config file
   if (context.options.requireConfigFile) {
     // Remove mainConfigFile from src files
-    var requireConfigFiles = grunt.util._.flatten([context.options.requireConfigFile]);
+    var requireConfigFiles = _.flatten([context.options.requireConfigFile]);
 
-    var normalizedPaths = grunt.util._.map(requireConfigFiles, function(configFile){
+    var normalizedPaths = _.map(requireConfigFiles, function(configFile){
       return path.normalize(configFile);
     });
-    context.scripts.src = grunt.util._.reject(context.scripts.src, function (script) {
-      return grunt.util._.contains(normalizedPaths, path.normalize(script));
+    context.scripts.src = _.reject(context.scripts.src, function (script) {
+      return _.includes(normalizedPaths, path.normalize(script));
     });
 
     var configFromFiles = {};
-    grunt.util._.map(requireConfigFiles, function (configFile) {
-      grunt.util._.merge(configFromFiles, parse.findConfig(grunt.file.read(configFile)).config);
+    _.map(requireConfigFiles, function (configFile) {
+      _.merge(configFromFiles, parse.findConfig(grunt.file.read(configFile)).config);
     });
 
-    context.options.requireConfig = grunt.util._.merge(configFromFiles, context.options.requireConfig);
+    context.options.requireConfig = _.merge(configFromFiles, context.options.requireConfig);
   }
 
 
@@ -119,7 +120,7 @@ exports.process = function(grunt, task, context) {
   }
 
   // Remove baseUrl and .js from src files
-  context.scripts.src = grunt.util._.map(context.scripts.src, getRelativeModuleUrl);
+  context.scripts.src = _.map(context.scripts.src, getRelativeModuleUrl);
 
 
   // Prepend loaderPlugins to the appropriate files
@@ -173,5 +174,7 @@ exports.process = function(grunt, task, context) {
                                context.temp);
 
   var source = grunt.file.read(template);
-  return grunt.util._.template(source, context);
+  var tpl = _.template(source);
+
+  return tpl(context);
 };


### PR DESCRIPTION
I left upgrading `grunt-contrib-jasmine` to the most recent version out of #94. This PR bases on #94 and uses a different way to copy files to temp directory, compatible with both older and newer versions, than `grunt-contrib-jasmine` 1.2.0.

`grunt-contrib-jasmine` broke their interface between 1.0.3 and 1.2.0 without increasing the major version number. (!!!) The method `task.copyTempFile` does not copy the source file to the temp directory any more. You would have provide the full path to the temp directory yourself. It made this method a pure wrapper of `grunt.file.copy` with no added functionality and a confusing name. This should be discussed with `grunt-contrib-jasmine` developers.