### PR TITLE
Perform Travis CI builds on Node.js LTS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - '10'
+  - '8'
+  - '6'
 before_install:
-  - npm install -g grunt-cli
-script: grunt
+  - npm i -g npm
+  - npm i -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Requirejs template for grunt-contrib-jasmine",
   "main": "src/template-jasmine-requirejs.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Build on Node.js 6, 8 and 10. Not on the obsolete 0.10 any more.

Travis builds with Puppeteer fail, because their Docker environment require enabling of Chrome sandbox mode. I want to look at it later.